### PR TITLE
canvia color del gat al hoverejar links

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,18 +5,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
     <link rel="stylesheet" href="style.css">
+    <script src="script.js" defer></script>
 </head>
 <body>
+    <div class="bg"></div>
+
     <h1 class="títol">judit casals</h1>
     <h2 class="títol">sonòloga (entre d'altres)</h2>
     <h3>com a sonòloga:</h3>
-    <p>-> et puc gravar <a href="https://youtu.be/zpkDYTTWvII?si=b6vDhys9H3OdF6bA">coses</a></p>
-    <p>-> i et puc mesclar i masteritzar <a href="https://youtu.be/XeMSZA0h-X8?si=SZlMQJEFmDJi21H2">coses</a></p>
+    <p>-> et puc gravar <a data-bg-hue=0.2 href="https://youtu.be/zpkDYTTWvII?si=b6vDhys9H3OdF6bA">coses</a></p>
+    <p>-> i et puc mesclar i masteritzar <a data-bg-hue=0.3 href="https://youtu.be/XeMSZA0h-X8?si=SZlMQJEFmDJi21H2">coses</a></p>
     <h3>com a pianista:</h3>
-    <p>-> puc tocar <a href="https://youtu.be/QyTdO2ezznM?si=Owk8Rwf8mRTi1n8J">clàssica</a></p>
-    <p>-> però també <a href="https://youtu.be/F6XxA4CjfQw?si=HDxMVEPNeUPpieEN">ska</a></p>
-    <p>-> o <a href="https://youtu.be/Vfj_1IrDue4?si=mO3z8l-jv4o0xR6j">pop</a></p>
-    <p>-> però és que també coses més aviat <a href="https://youtu.be/zU2vXKxoAD0?si=hkmuP-1fIYo5W9CK">estranyes</a></p>
+    <p>-> puc tocar <a data-bg-hue=0.5 href="https://youtu.be/QyTdO2ezznM?si=Owk8Rwf8mRTi1n8J">clàssica</a></p>
+    <p>-> però també <a data-bg-hue=0.6 href="https://youtu.be/F6XxA4CjfQw?si=HDxMVEPNeUPpieEN">ska</a></p>
+    <p>-> o <a data-bg-hue=0.67 href="https://youtu.be/Vfj_1IrDue4?si=mO3z8l-jv4o0xR6j">pop</a></p>
+    <p>-> però és que també coses més aviat <a data-bg-hue=0.8 href="https://youtu.be/zU2vXKxoAD0?si=hkmuP-1fIYo5W9CK">estranyes</a></p>
     <h3>i també m'agrada...</h3>
     <p>...llegir</p>
     <p>...ballar claqué</p>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,13 @@
+// aquesta línea updatea el valor de la variable --hover-bg-hue, com que si fos:
+// :root {
+//   --hover-bg-hue: <el_valor_de_hue>
+// }
+const updateHoverHue = (hue) => document.documentElement.style.setProperty('--hover-bg-hue', hue);
+
+// aquesta part selecciona tots els elements que tinguin [data-bg-hue]
+// i fa que la variable --hover-bg-hue s'actualitzi amb el seu valor de hue
+// quan posem el mouse a sobre o quan fem focus amb la tecla 'tab'
+document.querySelectorAll('[data-bg-hue]').forEach(el => {
+    el.addEventListener('pointerenter', () => updateHoverHue(el.dataset.bgHue));
+    el.addEventListener('focus', () => updateHoverHue(el.dataset.bgHue));
+})

--- a/style.css
+++ b/style.css
@@ -1,8 +1,27 @@
-*{
-    background-image: url("gat-pixel.png");
-    font-family: "Comic Sans MS", "Comic Sans", cursive;
-    text-align: center; 
+:root {
+	--bg-hue: 0;
+	/* aquest selector de sota diu: si dins de mi algun element amb data-bg-hue
+	està hovereat o focusejat, farem que --bg-hue sigui el seu valor
+	(que hem aconseguit amb script.js) */
+	&:has([data-bg-hue]:hover, [data-bg-hue]:focus) {
+		--bg-hue: var(--hover-bg-hue, 0);
+	}
 }
+
+.bg {
+	background-image: url("gat-pixel.png");
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	filter: hue-rotate(calc(var(--bg-hue) * 1turn));
+	z-index: -1; /* s'ha de posar a sota perquè la propietat 'filter' el fa estar a sobre si no */
+}
+
+* {
+    font-family: "Comic Sans MS", "Comic Sans", cursive;
+    text-align: center;
+}
+
 #upper_left {
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
Per canviar el color de l'imatge, he fet servir la propietat de css `filter: hue-rotate`. a aquest se'l pot donar un valor entre 0 i 1 per canviar el color de l'imatge.
Com que abans l'imatge era el background del document sencer, posar aquest filtre canviava totes les imatges alhora. Perque no fos així, he fet que l'imatge fos el background d'un element apart, fent servir el mateix truc de position: absolute que fas servir per les teves altres fotos.

L'idea per canviar el color del gat és que als elements de html els pots donar un atribut que li he dit data-bg-hue i que pot estar entre 0 i 1.
Quan el ratolí és a sobre, aquest valor del filter:hue-rotate canvia.